### PR TITLE
Add option to specify dataSlice in getAccountInfo

### DIFF
--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -249,7 +249,8 @@ class Connection {
   /// 1. Build requests
   ///
   json getAccountInfoRequest(const std::string &account,
-                             const std::string &encoding = "base64");
+                             const std::string &encoding = "base64",
+                             const size_t offset = 0, const size_t length = 0);
   json getRecentBlockhashRequest(const std::string &commitment = "finalized");
   json sendTransactionRequest(
       const std::string &transaction, const std::string &encoding = "base58",
@@ -266,8 +267,10 @@ class Connection {
       bool skipPreflight = false,
       const std::string &preflightCommitment = "finalized");
   template <typename T>
-  inline T getAccountInfo(const std::string &account) {
-    const json req = getAccountInfoRequest(account);
+  inline T getAccountInfo(const std::string &account,
+                          const std::string &encoding = "base64",
+                          const size_t offset = 0, const size_t length = 0) {
+    const json req = getAccountInfoRequest(account, encoding, offset, length);
     cpr::Response r =
         cpr::Post(cpr::Url{rpc_url_}, cpr::Body{req.dump()},
                   cpr::Header{{"Content-Type", "application/json"}});

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -18,8 +18,16 @@ Connection::Connection(const std::string &rpc_url,
 /// 1. Build requests
 ///
 json Connection::getAccountInfoRequest(const std::string &account,
-                                       const std::string &encoding) {
-  const json params = {account, {{"encoding", encoding}}};
+                                       const std::string &encoding,
+                                       const size_t offset,
+                                       const size_t length) {
+  json params = {account};
+  json options = {{"encoding", encoding}};
+  if (offset && length) {
+    json dataSlice = {"dataSlice", {{"offset", offset}, {"length", length}}};
+    options.emplace(dataSlice);
+  }
+  params.emplace_back(options);
 
   return jsonRequest("getAccountInfo", params);
 }


### PR DESCRIPTION
User can specify `dataSlice` options: 
```cpp
const json req = connection.getAccountInfoRequest(pubkey, 10, 100); // offset, lenght
```
```json
{"id":1,"jsonrpc":"2.0","method":"getAccountInfo","params":["98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue",{"dataSlice":{"length":10,"offset":10},"encoding":"base64"}]}
```