### PR TITLE
Code vuln scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,61 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Conan
+        uses: turtlebrowser/get-conan@v1.0
+
+      - name: Create default profile
+        run: conan profile new default --detect --force
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.conan
+          key: ${{ runner.os }}-conan-${{ hashFiles('**/conanfile.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-conan-
+            
+      - name: Override default profile
+        run:
+          rsync --checksum
+          ${{github.workspace}}/conan_profile.linux
+          ~/.conan/profiles/default
+
+      - name: Install dependencies
+        run:
+          conan install . -s build_type=Release
+          --install-folder=${{github.workspace}}/build --build=missing -o:h
+          boost:without_fiber=True -o:h boost:without_python=True
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+
+      # Initialised pre-build to monitor the build process
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: 'cpp'
+          
+      - name: Build
+        run:
+          cmake --build ${{github.workspace}}/build --config Release --verbose
+
+      # Run security tests against build and log to the security center
+      - name: Perform CodeQL Analysis
+        continue-on-error: true
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,7 @@ on:
     
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     permissions:
       security-events: write
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,9 +50,10 @@ jobs:
 
       # Initialised pre-build to monitor the build process
       - name: Initialize CodeQL
+        if: ${{matrix.config.profile}} = 'linux'
         uses: github/codeql-action/init@v1
         with:
-          languages: cpp
+          languages: 'cpp'
           
       - name: Build
         run:
@@ -60,6 +61,7 @@ jobs:
 
       # Run security tests against build and log to the security center
       - name: Perform CodeQL Analysis
+        if: ${{matrix.config.profile}} = 'linux'
         continue-on-error: true
         uses: github/codeql-action/analyze@v1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    
 jobs:
   build:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,17 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    
 jobs:
   build:
     runs-on: ${{ matrix.config.os }}
-    permissions:
-      security-events: write
     strategy:
-      fail-fast: false
       matrix:
         config:
-          - { os: "ubuntu-latest", profile: "linux" }
+          - { os: "ubuntu-18.04", profile: "linux" }
           - { os: "macos-latest", profile: "macos" }
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +28,6 @@ jobs:
           key: ${{ runner.os }}-conan-${{ hashFiles('**/conanfile.txt') }}
           restore-keys: |
             ${{ runner.os }}-conan-
-
       - name: Override default profile
         run:
           rsync --checksum
@@ -48,22 +43,9 @@ jobs:
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
 
-      # Initialised pre-build to monitor the build process
-      - name: Initialize CodeQL
-        if: ${{matrix.config.profile == 'linux'}}
-        uses: github/codeql-action/init@v1
-        with:
-          languages: 'cpp'
-          
       - name: Build
         run:
           cmake --build ${{github.workspace}}/build --config Release --verbose
-
-      # Run security tests against build and log to the security center
-      - name: Perform CodeQL Analysis
-        if: ${{matrix.config.profile == 'linux' }}
-        continue-on-error: true
-        uses: github/codeql-action/analyze@v1
 
       - name: Test
         run: cd ${{github.workspace}}/build && ./bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initialised pre-build to monitor the build process
       - name: Initialize CodeQL
-        if: ${{matrix.config.profile}} == 'linux'
+        if: ${{matrix.config.profile == 'linux'}}
         uses: github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -61,7 +61,7 @@ jobs:
 
       # Run security tests against build and log to the security center
       - name: Perform CodeQL Analysis
-        if: ${{matrix.config.profile}} == 'linux'
+        if: ${{matrix.config.profile == 'linux' }}
         continue-on-error: true
         uses: github/codeql-action/analyze@v1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,13 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.config.os }}
+    permissions:
+      security-events: write
     strategy:
+      fail-fast: false
       matrix:
         config:
-          - { os: "ubuntu-18.04", profile: "linux" }
+          - { os: "ubuntu-latest", profile: "linux" }
           - { os: "macos-latest", profile: "macos" }
     steps:
       - uses: actions/checkout@v2
@@ -44,9 +47,20 @@ jobs:
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
 
+      # Initialised pre-build to monitor the build process
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: cpp
+          
       - name: Build
         run:
           cmake --build ${{github.workspace}}/build --config Release --verbose
+
+      # Run security tests against build and log to the security center
+      - name: Perform CodeQL Analysis
+        continue-on-error: true
+        uses: github/codeql-action/analyze@v1
 
       - name: Test
         run: cd ${{github.workspace}}/build && ./bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initialised pre-build to monitor the build process
       - name: Initialize CodeQL
-        if: ${{matrix.config.profile}} = 'linux'
+        if: ${{matrix.config.profile}} == 'linux'
         uses: github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -61,7 +61,7 @@ jobs:
 
       # Run security tests against build and log to the security center
       - name: Perform CodeQL Analysis
-        if: ${{matrix.config.profile}} = 'linux'
+        if: ${{matrix.config.profile}} == 'linux'
         continue-on-error: true
         uses: github/codeql-action/analyze@v1
 

--- a/conan_profile.linux
+++ b/conan_profile.linux
@@ -4,7 +4,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=gcc
-compiler.version=7
+compiler.version=9
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]

--- a/conan_profile.linux
+++ b/conan_profile.linux
@@ -4,7 +4,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=gcc
-compiler.version=9
+compiler.version=7
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]


### PR DESCRIPTION
Hey Max

This PR adds cpp code vulnerability scanning to the existing test job. It adds a bit of overhead to the jobs, especially since the matrix of running the job for both linux and macos. Could consider separating to only run once. Depends a bit how much activity is expected on the main branch

Good news, no immediate issues!