### PR TITLE
getMultipleAccounts

### DIFF
--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -7,8 +7,9 @@ using json = nlohmann::json;
 int main() {
   const auto& config = mango_v3::DEVNET;
   auto connection = solana::rpc::Connection(config.endpoint);
-  const auto& mangoAccountInfo = connection.getAccountInfo<mango_v3::MangoAccountInfo>(
-      "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW");
+  const auto& mangoAccountInfo =
+      connection.getAccountInfo<mango_v3::MangoAccountInfo>(
+          "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW");
   const auto& mangoAccount = mango_v3::MangoAccount(mangoAccountInfo);
   spdlog::info(mangoAccountInfo.owner.toBase58());
   spdlog::info(mangoAccount.accountInfo.owner.toBase58());

--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -9,7 +9,7 @@ int main() {
   auto connection = solana::rpc::Connection(config.endpoint);
   const auto& mangoAccountInfo = connection.getAccountInfo<mango_v3::MangoAccountInfo>(
       "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW");
-  const auto& mangoAccount = mango_v3::MangoAccount::from(std::move(mangoAccountInfo));
+  const auto& mangoAccount = mango_v3::MangoAccount::from(mangoAccountInfo);
   spdlog::info(mangoAccountInfo.owner.toBase58());
   spdlog::info(mangoAccount->getLiquidationPrice().toDouble());
   // TODO: #13

--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -7,8 +7,10 @@ using json = nlohmann::json;
 int main() {
   const auto& config = mango_v3::DEVNET;
   auto connection = solana::rpc::Connection(config.endpoint);
-  const auto& mangoAccount = connection.getAccountInfo<mango_v3::MangoAccount>(
+  const auto& mangoAccountInfo = connection.getAccountInfo<mango_v3::MangoAccountInfo>(
       "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW");
-  spdlog::info(mangoAccount.owner.toBase58());
+  const auto& mangoAccount = mango_v3::MangoAccount::from(std::move(mangoAccountInfo));
+  spdlog::info(mangoAccountInfo.owner.toBase58());
+  spdlog::info(mangoAccount->getLiquidationPrice().toDouble());
   // TODO: #13
 }

--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -9,8 +9,8 @@ int main() {
   auto connection = solana::rpc::Connection(config.endpoint);
   const auto& mangoAccountInfo = connection.getAccountInfo<mango_v3::MangoAccountInfo>(
       "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW");
-  const auto& mangoAccount = mango_v3::MangoAccount::from(mangoAccountInfo);
+  const auto& mangoAccount = mango_v3::MangoAccount(mangoAccountInfo);
   spdlog::info(mangoAccountInfo.owner.toBase58());
-  spdlog::info(mangoAccount->getLiquidationPrice().toDouble());
+  spdlog::info(mangoAccount.accountInfo.owner.toBase58());
   // TODO: #13
 }

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 #include <memory>
+<<<<<<< HEAD
 #include <utility>
+=======
+#include <string>
+
+>>>>>>> 159ac45 (style fixup)
 #include "fixedp.h"
 #include "int128.hpp"
 #include "solana.hpp"
@@ -155,7 +159,6 @@ struct MangoAccount {
     const auto& accountInfo_ = connection.getAccountInfo<MangoAccountInfo>(pubKey);
     accountInfo = accountInfo_;
   }
-};
 
 struct LiquidityMiningInfo {
   i80f48 rate;

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -1,13 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
-<<<<<<< HEAD
-#include <utility>
-=======
 #include <string>
 
->>>>>>> 159ac45 (style fixup)
 #include "fixedp.h"
 #include "int128.hpp"
 #include "solana.hpp"
@@ -148,17 +143,18 @@ struct MangoAccountInfo {
 
 struct MangoAccount {
   MangoAccountInfo accountInfo;
-  explicit MangoAccount(const MangoAccountInfo& accountInfo_) noexcept {
+  explicit MangoAccount(const MangoAccountInfo &accountInfo_) noexcept {
     accountInfo = accountInfo_;
   }
   // Fetch `accountInfo` from `endpoint` and decode it
-  explicit MangoAccount(const std::string& pubKey,
-               const std::string& endpoint = MAINNET.endpoint)
-  {
+  explicit MangoAccount(const std::string &pubKey,
+                        const std::string &endpoint = MAINNET.endpoint) {
     auto connection = solana::rpc::Connection(endpoint);
-    const auto& accountInfo_ = connection.getAccountInfo<MangoAccountInfo>(pubKey);
+    const auto &accountInfo_ =
+        connection.getAccountInfo<MangoAccountInfo>(pubKey);
     accountInfo = accountInfo_;
   }
+};
 
 struct LiquidityMiningInfo {
   i80f48 rate;

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <string>
-
+#include <memory>
 #include "fixedp.h"
 #include "int128.hpp"
 #include "solana.hpp"
@@ -147,28 +147,26 @@ class MangoAccount {
  // make the public constructor un-callable.
   struct NotPubliclyConstructible {};
  public:
-  MangoAccount(NotPubliclyConstructible /* npc */, const MangoAccountInfo&& accountInfo) noexcept
-      : accountInfo_(std::move(accountInfo)){}
+  MangoAccount(NotPubliclyConstructible /* npc */, const MangoAccountInfo& accountInfo) noexcept
+      : accountInfo_(accountInfo)  {}
   // Use a prefetched accountInfo
-  static std::unique_ptr<MangoAccount> from(const MangoAccountInfo&& accountInfo) noexcept {
-    return std::make_unique<MangoAccount>(NotPubliclyConstructible{}, std::move(accountInfo));
+  static std::unique_ptr<MangoAccount> from(const MangoAccountInfo& accountInfo) noexcept {
+    return std::make_unique<MangoAccount>(NotPubliclyConstructible{}, accountInfo);
   }
   // Fetch `accountInfo` from `endpoint` and decode it
   static std::unique_ptr<MangoAccount> from(const solana::PublicKey& pubKey,
                const std::string& endpoint = MAINNET.endpoint)
   {
     auto connection = solana::rpc::Connection(endpoint);
-    const auto accountInfo = connection.getAccountInfo<MangoAccountInfo>(pubKey.toBase58());
-    return std::make_unique<MangoAccount>(NotPubliclyConstructible{}, std::move(accountInfo));
+    const auto& accountInfo = connection.getAccountInfo<MangoAccountInfo>(pubKey.toBase58());
+    return std::make_unique<MangoAccount>(NotPubliclyConstructible{}, accountInfo);
   }
   i80f48 getLiquidationPrice(){
     return {};
   }
-  bool hasAnySpotOrders(){
-    return {};
-  }
+  // TODO: Add methods to calculate health ratio
  private:
-  const MangoAccountInfo accountInfo_;
+  const MangoAccountInfo& accountInfo_;
   // TODO: Add `spotOpenOrdersAccounts` and `advancedOrders`
 };
 

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -324,8 +324,7 @@ class Connection {
     int index = -1;
     for (const auto &account_info : account_info_vec) {
       ++index;
-      if(account_info.is_null())
-        continue;   // Account doesn't exist
+      if (account_info.is_null()) continue;  // Account doesn't exist
       const std::string encoded = account_info["data"][0];
       const std::string decoded = b64decode(encoded);
       if (decoded.size() != sizeof(T))
@@ -334,8 +333,8 @@ class Connection {
                                  std::to_string(sizeof(T)));
       T account;
       memcpy(&account, decoded.data(), sizeof(T));
-      result[req["params"][0][index]] = account; // Retrieve the corresponding
-                                                 // pubKey from the request
+      result[req["params"][0][index]] = account;  // Retrieve the corresponding
+                                                  // pubKey from the request
     }
     return result;
   }

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -255,9 +255,10 @@ class Connection {
   json getAccountInfoRequest(const std::string &account,
                              const std::string &encoding = "base64",
                              const size_t offset = 0, const size_t length = 0);
-  json getMultipleAccountsRequest(const std::vector<std::string>& accounts,
+  json getMultipleAccountsRequest(const std::vector<std::string> &accounts,
                                   const std::string &encoding = "base64",
-                                  const size_t offset = 0, const size_t length = 0);
+                                  const size_t offset = 0,
+                                  const size_t length = 0);
   json getBlockhashRequest(const std::string &commitment = "finalized",
                            const std::string &method = "getRecentBlockhash");
   json sendTransactionRequest(
@@ -302,10 +303,12 @@ class Connection {
   }
   /// Returns account information for a list of pubKeys
   template <typename T>
-  inline std::vector<T> getMultipleAccounts(const std::vector<std::string>& accounts,
-                          const std::string &encoding = "base64",
-                          const size_t offset = 0, const size_t length = 0){
-    const json req = getMultipleAccountsRequest(accounts, encoding, offset, length);
+  inline std::vector<T> getMultipleAccounts(
+      const std::vector<std::string> &accounts,
+      const std::string &encoding = "base64", const size_t offset = 0,
+      const size_t length = 0) {
+    const json req =
+        getMultipleAccountsRequest(accounts, encoding, offset, length);
     cpr::Response r =
         cpr::Post(cpr::Url{rpc_url_}, cpr::Body{req.dump()},
                   cpr::Header{{"Content-Type", "application/json"}});
@@ -314,11 +317,11 @@ class Connection {
                                std::to_string(r.status_code));
 
     json res = json::parse(r.text);
-    const auto& account_info_vec = res["result"]["value"];
+    const auto &account_info_vec = res["result"]["value"];
     std::vector<T> result(account_info_vec.size());
     int i = 0;
-    for(const auto& account_info: account_info_vec){
-      assert(!account_info.is_null()); // Account doesn't exist
+    for (const auto &account_info : account_info_vec) {
+      assert(!account_info.is_null());  // Account doesn't exist
       const std::string encoded = account_info["data"][0];
       const std::string decoded = b64decode(encoded);
       if (decoded.size() != sizeof(T))

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -255,6 +255,9 @@ class Connection {
   json getAccountInfoRequest(const std::string &account,
                              const std::string &encoding = "base64",
                              const size_t offset = 0, const size_t length = 0);
+  json getMultipleAccountsRequest(const std::vector<std::string>& accounts,
+                                  const std::string &encoding = "base64",
+                                  const size_t offset = 0, const size_t length = 0);
   json getBlockhashRequest(const std::string &commitment = "finalized",
                            const std::string &method = "getRecentBlockhash");
   json sendTransactionRequest(
@@ -295,6 +298,38 @@ class Connection {
 
     T result;
     memcpy(&result, decoded.data(), sizeof(T));
+    return result;
+  }
+  /// Returns account information for a list of pubKeys
+  template <typename T>
+  inline std::vector<T> getMultipleAccounts(const std::vector<std::string>& accounts,
+                          const std::string &encoding = "base64",
+                          const size_t offset = 0, const size_t length = 0){
+    const json req = getMultipleAccountsRequest(accounts, encoding, offset, length);
+    cpr::Response r =
+        cpr::Post(cpr::Url{rpc_url_}, cpr::Body{req.dump()},
+                  cpr::Header{{"Content-Type", "application/json"}});
+    if (r.status_code != 200)
+      throw std::runtime_error("unexpected status_code " +
+                               std::to_string(r.status_code));
+
+    json res = json::parse(r.text);
+    const auto& account_info_vec = res["result"]["value"];
+    std::vector<T> result(account_info_vec.size());
+    int i = 0;
+    for(const auto& account_info: account_info_vec){
+      assert(!account_info.is_null()); // Account doesn't exist
+      const std::string encoded = account_info["data"][0];
+      const std::string decoded = b64decode(encoded);
+      if (decoded.size() != sizeof(T))
+        throw std::runtime_error("invalid response length " +
+                                 std::to_string(decoded.size()) + " expected " +
+                                 std::to_string(sizeof(T)));
+      T account;
+      memcpy(&account, decoded.data(), sizeof(T));
+      result[i] = account;
+      ++i;
+    }
     return result;
   }
 

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -31,6 +31,24 @@ json Connection::getAccountInfoRequest(const std::string &account,
 
   return jsonRequest("getAccountInfo", params);
 }
+json Connection::getMultipleAccountsRequest(const std::vector<std::string>& accounts,
+                                const std::string &encoding,
+                                const size_t offset, const size_t length){
+  json pubKeys = json::array();
+  for(auto& account: accounts){
+    pubKeys.emplace_back(account);
+  }
+  json params = {};
+  params.emplace_back(pubKeys);
+  json options = {{"encoding", encoding}};
+  if (offset && length) {
+    json dataSlice = {"dataSlice", {{"offset", offset}, {"length", length}}};
+    options.emplace(dataSlice);
+  }
+  params.emplace_back(options);
+
+  return jsonRequest("getMultipleAccounts", params);
+}
 json Connection::getBlockhashRequest(const std::string &commitment,
                                      const std::string &method) {
   const json params = {{{"commitment", commitment}}};

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -31,11 +31,11 @@ json Connection::getAccountInfoRequest(const std::string &account,
 
   return jsonRequest("getAccountInfo", params);
 }
-json Connection::getMultipleAccountsRequest(const std::vector<std::string>& accounts,
-                                const std::string &encoding,
-                                const size_t offset, const size_t length){
+json Connection::getMultipleAccountsRequest(
+    const std::vector<std::string> &accounts, const std::string &encoding,
+    const size_t offset, const size_t length) {
   json pubKeys = json::array();
-  for(auto& account: accounts){
+  for (auto &account : accounts) {
     pubKeys.emplace_back(account);
   }
   json params = {};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -97,3 +97,19 @@ TEST_CASE("Test getLatestBlock") {
   CHECK(!blockHash.publicKey.toBase58().empty());
   CHECK_GT(blockHash.lastValidBlockHeight, 0);
 }
+TEST_CASE("MangoAccount is correctly created"){
+  const std::string& key = "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW";
+  auto connection = solana::rpc::Connection(mango_v3::DEVNET.endpoint);
+  const auto& mangoAccountInfo =
+      connection.getAccountInfo<mango_v3::MangoAccountInfo>(key);
+  // Test prefetched account info
+  REQUIRE_NOTHROW(mango_v3::MangoAccount::from(std::move(mangoAccountInfo)));
+  const auto& mangoAccountInfo_ =
+      connection.getAccountInfo<mango_v3::MangoAccountInfo>(key);
+  const auto& mangoAccount = mango_v3::MangoAccount::from(std::move(mangoAccountInfo_));
+  CHECK(!std::is_null_pointer<decltype(mangoAccount)>::value);
+  // Test fetching account info in construction
+  REQUIRE_NOTHROW(mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint));
+  const auto& accountInfo = mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint);
+  CHECK(!std::is_null_pointer<decltype(mangoAccount)>::value);
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -103,13 +103,13 @@ TEST_CASE("MangoAccount is correctly created"){
   const auto& mangoAccountInfo =
       connection.getAccountInfo<mango_v3::MangoAccountInfo>(key);
   // Test prefetched account info
-  REQUIRE_NOTHROW(mango_v3::MangoAccount::from(std::move(mangoAccountInfo)));
+  REQUIRE_NOTHROW(mango_v3::MangoAccount::from(mangoAccountInfo));
   const auto& mangoAccountInfo_ =
       connection.getAccountInfo<mango_v3::MangoAccountInfo>(key);
-  const auto& mangoAccount = mango_v3::MangoAccount::from(std::move(mangoAccountInfo_));
+   const auto& mangoAccount = mango_v3::MangoAccount::from(mangoAccountInfo_);
   CHECK(!std::is_null_pointer<decltype(mangoAccount)>::value);
   // Test fetching account info in construction
   REQUIRE_NOTHROW(mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint));
-  const auto& accountInfo = mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint);
-  CHECK(!std::is_null_pointer<decltype(mangoAccount)>::value);
+  const auto& account = mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint);
+  CHECK(!std::is_null_pointer<decltype(account)>::value);
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Test getMultipleAccounts") {
   it = accountInfoMap.find(accounts[1]);
   CHECK_NE(it, accountInfoMap.end());
   // Check AccountInfo is non-empty
-  for (const auto& [pubKey, accountInfo]: accountInfoMap) {
+  for (const auto& [pubKey, accountInfo] : accountInfoMap) {
     auto owner = accountInfo.owner;
     CHECK(!(owner == solana::PublicKey::empty()));
   }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -111,14 +111,15 @@ TEST_CASE("MangoAccount is correctly created") {
   CHECK(!account.accountInfo.owner.toBase58().empty());
 }
 TEST_CASE("Test getMultipleAccounts") {
-  const std::vector<std::string> accounts {
+  const std::vector<std::string> accounts{
       "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW",
       "DRUZRfLQtki4ZYvRXhi5yGmyqCf6iMfTzxtBpxo6rbHu",
   };
   auto connection = solana::rpc::Connection(mango_v3::DEVNET.endpoint);
-  auto accountInfoVec = connection.getMultipleAccounts<mango_v3::MangoAccountInfo>(accounts);
+  auto accountInfoVec =
+      connection.getMultipleAccounts<mango_v3::MangoAccountInfo>(accounts);
   REQUIRE_EQ(accountInfoVec.size(), accounts.size());
   for (const auto& accountInfo : accountInfoVec) {
-    CHECK(!(accountInfo.owner==solana::PublicKey::empty()));
+    CHECK(!(accountInfo.owner == solana::PublicKey::empty()));
   }
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -12,7 +12,7 @@ TEST_CASE("base58 decode & encode") {
       "14ivtgssEBoBjuZJtSAPKYgpUK7DmnSwuPMqJoVTSgKJ"};
 
   std::string resources_dir = FIXTURES_DIR;
-  for (const auto &bs58 : bs58s) {
+  for (const auto& bs58 : bs58s) {
     const auto decoded = solana::b58decode(bs58);
     const auto encoded = solana::b58encode(decoded);
     const auto redecoded = solana::b58decode(encoded);
@@ -45,7 +45,7 @@ TEST_CASE("decode mango_v3 Fill") {
       "Tgm1NbL9IaU3AQAAAADOMAYAAAAAAAAAAAAAAAAA46WbxCAAAAAAAAAAAAAAAHJYBgAAAAAA"
       "AQAAAAAAAAA=");
   const std::string decoded = solana::b64decode(encoded);
-  const mango_v3::FillEvent *event = (mango_v3::FillEvent *)decoded.data();
+  const mango_v3::FillEvent* event = (mango_v3::FillEvent*)decoded.data();
   CHECK_EQ(event->eventType, mango_v3::EventType::Fill);
   CHECK_EQ(event->takerSide, mango_v3::Side::Sell);
   CHECK_EQ(event->makerOut, 0);
@@ -97,7 +97,7 @@ TEST_CASE("Test getLatestBlock") {
   CHECK(!blockHash.publicKey.toBase58().empty());
   CHECK_GT(blockHash.lastValidBlockHeight, 0);
 }
-TEST_CASE("MangoAccount is correctly created"){
+TEST_CASE("MangoAccount is correctly created") {
   const std::string& key = "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW";
   auto connection = solana::rpc::Connection(mango_v3::DEVNET.endpoint);
   // Test prefetched account info

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -110,3 +110,15 @@ TEST_CASE("MangoAccount is correctly created") {
   const auto& account = mango_v3::MangoAccount(key, mango_v3::DEVNET.endpoint);
   CHECK(!account.accountInfo.owner.toBase58().empty());
 }
+TEST_CASE("Test getMultipleAccounts") {
+  const std::vector<std::string> accounts {
+      "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW",
+      "DRUZRfLQtki4ZYvRXhi5yGmyqCf6iMfTzxtBpxo6rbHu",
+  };
+  auto connection = solana::rpc::Connection(mango_v3::DEVNET.endpoint);
+  auto accountInfoVec = connection.getMultipleAccounts<mango_v3::MangoAccountInfo>(accounts);
+  REQUIRE_EQ(accountInfoVec.size(), accounts.size());
+  for (const auto& accountInfo : accountInfoVec) {
+    CHECK(!(accountInfo.owner==solana::PublicKey::empty()));
+  }
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -100,16 +100,13 @@ TEST_CASE("Test getLatestBlock") {
 TEST_CASE("MangoAccount is correctly created"){
   const std::string& key = "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW";
   auto connection = solana::rpc::Connection(mango_v3::DEVNET.endpoint);
+  // Test prefetched account info
   const auto& mangoAccountInfo =
       connection.getAccountInfo<mango_v3::MangoAccountInfo>(key);
-  // Test prefetched account info
-  REQUIRE_NOTHROW(mango_v3::MangoAccount::from(mangoAccountInfo));
-  const auto& mangoAccountInfo_ =
-      connection.getAccountInfo<mango_v3::MangoAccountInfo>(key);
-   const auto& mangoAccount = mango_v3::MangoAccount::from(mangoAccountInfo_);
-  CHECK(!std::is_null_pointer<decltype(mangoAccount)>::value);
+  const auto& mangoAccount = mango_v3::MangoAccount(mangoAccountInfo);
+  CHECK(!mangoAccount.accountInfo.owner.toBase58().empty());
   // Test fetching account info in construction
-  REQUIRE_NOTHROW(mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint));
-  const auto& account = mango_v3::MangoAccount::from(solana::PublicKey::fromBase58(key), mango_v3::DEVNET.endpoint);
-  CHECK(!std::is_null_pointer<decltype(account)>::value);
+  REQUIRE_NOTHROW(mango_v3::MangoAccount(key, mango_v3::DEVNET.endpoint));
+  const auto& account = mango_v3::MangoAccount(key, mango_v3::DEVNET.endpoint);
+  CHECK(!account.accountInfo.owner.toBase58().empty());
 }


### PR DESCRIPTION
- [`getMultipleAccounts`](https://docs.solana.com/developing/clients/jsonrpc-api#getmultipleaccounts). Seems to be used in fetching OpenOrders.
  - Returns a map of {pubKey : AccountInfo} for accounts that exist.
  - Accounts that don't exist return a `null` result and are skipped in result
- Tests for it.