### PR TITLE
Load OpenOrders for MangoAccount

### DIFF
--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -13,7 +13,6 @@ int main() {
   mango_v3::MangoAccount mangoAccount =
       mango_v3::MangoAccount(mangoAccountInfo);
   spdlog::info("Owner: ", mangoAccountInfo.owner.toBase58());
-  ;
   auto openOrders = mangoAccount.loadOpenOrders(connection);
   spdlog::info("---OpenOrders:{}---", openOrders.size());
   for (auto& openOrder : openOrders) {

--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -10,11 +10,13 @@ int main() {
   const auto& mangoAccountInfo =
       connection.getAccountInfo<mango_v3::MangoAccountInfo>(
           "F3TTrgxjrkAHdS9zEidtwU5VXyvMgr5poii4HYatZheH");
-  mango_v3::MangoAccount mangoAccount = mango_v3::MangoAccount(mangoAccountInfo);
-  spdlog::info("Owner: ", mangoAccountInfo.owner.toBase58());;
+  mango_v3::MangoAccount mangoAccount =
+      mango_v3::MangoAccount(mangoAccountInfo);
+  spdlog::info("Owner: ", mangoAccountInfo.owner.toBase58());
+  ;
   auto openOrders = mangoAccount.loadOpenOrders(connection);
   spdlog::info("---OpenOrders:{}---", openOrders.size());
-  for(auto& openOrder: openOrders){
+  for (auto& openOrder : openOrders) {
     spdlog::info("Address: {}", openOrder.first);
     spdlog::info("Owner: {}", openOrder.second.owner.toBase58());
     spdlog::info("Market: {}", openOrder.second.market.toBase58());

--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -19,7 +19,6 @@ int main() {
     spdlog::info("Address: {}", openOrder.first);
     spdlog::info("Owner: {}", openOrder.second.owner.toBase58());
     spdlog::info("Market: {}", openOrder.second.market.toBase58());
-    spdlog::info("AccountFlags: {}", openOrder.second.accountFlags.to_string());
     spdlog::info("baseTokenFree: {}", openOrder.second.baseTokenFree);
     spdlog::info("baseTokenTotal: {}", openOrder.second.baseTokenTotal);
     spdlog::info("quoteTokenFree: {}", openOrder.second.quoteTokenFree);

--- a/examples/positions.cpp
+++ b/examples/positions.cpp
@@ -5,13 +5,24 @@
 using json = nlohmann::json;
 
 int main() {
-  const auto& config = mango_v3::DEVNET;
+  const auto& config = mango_v3::MAINNET;
   auto connection = solana::rpc::Connection(config.endpoint);
   const auto& mangoAccountInfo =
       connection.getAccountInfo<mango_v3::MangoAccountInfo>(
-          "9aWg1jhgRzGRmYWLbTrorCFE7BQbaz2dE5nYKmqeLGCW");
-  const auto& mangoAccount = mango_v3::MangoAccount(mangoAccountInfo);
-  spdlog::info(mangoAccountInfo.owner.toBase58());
-  spdlog::info(mangoAccount.accountInfo.owner.toBase58());
+          "F3TTrgxjrkAHdS9zEidtwU5VXyvMgr5poii4HYatZheH");
+  mango_v3::MangoAccount mangoAccount = mango_v3::MangoAccount(mangoAccountInfo);
+  spdlog::info("Owner: ", mangoAccountInfo.owner.toBase58());;
+  auto openOrders = mangoAccount.loadOpenOrders(connection);
+  spdlog::info("---OpenOrders:{}---", openOrders.size());
+  for(auto& openOrder: openOrders){
+    spdlog::info("Address: {}", openOrder.first);
+    spdlog::info("Owner: {}", openOrder.second.owner.toBase58());
+    spdlog::info("Market: {}", openOrder.second.market.toBase58());
+    spdlog::info("AccountFlags: {}", openOrder.second.accountFlags.to_string());
+    spdlog::info("baseTokenFree: {}", openOrder.second.baseTokenFree);
+    spdlog::info("baseTokenTotal: {}", openOrder.second.baseTokenTotal);
+    spdlog::info("quoteTokenFree: {}", openOrder.second.quoteTokenFree);
+    spdlog::info("quoteTokenTotal: {}", openOrder.second.quoteTokenTotal);
+  }
   // TODO: #13
 }

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <string>
-#include <unordered_map>
 
 #include "fixedp.h"
 #include "int128.hpp"

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -6,8 +6,8 @@
 
 #include "fixedp.h"
 #include "int128.hpp"
-#include "solana.hpp"
 #include "serum_v3.hpp"
+#include "solana.hpp"
 
 namespace mango_v3 {
 using json = nlohmann::json;
@@ -143,7 +143,6 @@ struct MangoAccountInfo {
   uint8_t padding[5];
 };
 
-
 struct MangoAccount {
   MangoAccountInfo accountInfo;
   std::map<std::string, serum_v3::OpenOrders>
@@ -179,8 +178,12 @@ std::map<std::string, serum_v3::OpenOrders> MangoAccount::loadOpenOrders(
       std::inserter(spotOpenOrdersAccounts, spotOpenOrdersAccounts.end()),
       [](auto &accountInfo) {
         // Check initialized and OpenOrders account flags
-        return !((accountInfo.second.accountFlags & serum_v3::AccountFlag::Initialized) != serum_v3::AccountFlag::Initialized ||
-                 (accountInfo.second.accountFlags & serum_v3::AccountFlag::OpenOrders) != serum_v3::AccountFlag::OpenOrders);
+        return !((accountInfo.second.accountFlags &
+                  serum_v3::AccountFlag::Initialized) !=
+                     serum_v3::AccountFlag::Initialized ||
+                 (accountInfo.second.accountFlags &
+                  serum_v3::AccountFlag::OpenOrders) !=
+                     serum_v3::AccountFlag::OpenOrders);
       });
   return spotOpenOrdersAccounts;
 }

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <bitset>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
-#include <bitset>
 
 #include "fixedp.h"
 #include "int128.hpp"
@@ -48,11 +48,10 @@ const std::unordered_map<std::string, size_t> SERUM_PROGRAM_LAYOUT_VERSIONS = {
     {"4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn", 1},
     {"BJ3jrUzddfuSrZHXSCxMUUQsjKEyLmuuyZebkcaFp2fg", 1},
     {"EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o", 2},
-    {"9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin", 3}
-};
-size_t  getLayoutVersion(std::string programId){
+    {"9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin", 3}};
+size_t getLayoutVersion(std::string programId) {
   auto it = SERUM_PROGRAM_LAYOUT_VERSIONS.find(programId);
-  return (it != SERUM_PROGRAM_LAYOUT_VERSIONS.end())?it->second:3;
+  return (it != SERUM_PROGRAM_LAYOUT_VERSIONS.end()) ? it->second : 3;
 }
 // all rust structs assume padding to 8
 #pragma pack(push, 8)
@@ -182,7 +181,8 @@ struct OpenOrders {
 
 struct MangoAccount {
   MangoAccountInfo accountInfo;
-  std::map<std::string, OpenOrders> spotOpenOrdersAccounts; // Address, AccountInfo
+  std::map<std::string, OpenOrders>
+      spotOpenOrdersAccounts;  // Address, AccountInfo
   explicit MangoAccount(const MangoAccountInfo &accountInfo_) noexcept {
     accountInfo = accountInfo_;
   }
@@ -194,25 +194,29 @@ struct MangoAccount {
         connection.getAccountInfo<MangoAccountInfo>(pubKey);
     accountInfo = accountInfo_;
   }
-  std::map<std::string, OpenOrders> loadOpenOrders(solana::rpc::Connection& connection);
+  std::map<std::string, OpenOrders> loadOpenOrders(
+      solana::rpc::Connection &connection);
 };
-std::map<std::string, OpenOrders> MangoAccount::loadOpenOrders(solana::rpc::Connection &connection) {
+std::map<std::string, OpenOrders> MangoAccount::loadOpenOrders(
+    solana::rpc::Connection &connection) {
   // Filter only non-empty open orders
   std::vector<std::string> filteredOpenOrders;
-  for(auto item: accountInfo.spotOpenOrders){
-    if(item == solana::PublicKey::empty())
-      continue;
+  for (auto item : accountInfo.spotOpenOrders) {
+    if (item == solana::PublicKey::empty()) continue;
     filteredOpenOrders.emplace_back(std::move(item.toBase58()));
   }
   // Fetch account info, OpenOrdersV2
-  const auto accountsInfo = connection.getMultipleAccounts<OpenOrders>(filteredOpenOrders);
+  const auto accountsInfo =
+      connection.getMultipleAccounts<OpenOrders>(filteredOpenOrders);
   spotOpenOrdersAccounts.clear();
-  std::copy_if(accountsInfo.begin(), accountsInfo.end(),
-               std::inserter(spotOpenOrdersAccounts, spotOpenOrdersAccounts.end()), [](auto& accountInfo){
-    // Check initialized and OpenOrders account flags
-    return !(!accountInfo.second.accountFlags[0]
-           || !accountInfo.second.accountFlags[2]);
-  });
+  std::copy_if(
+      accountsInfo.begin(), accountsInfo.end(),
+      std::inserter(spotOpenOrdersAccounts, spotOpenOrdersAccounts.end()),
+      [](auto &accountInfo) {
+        // Check initialized and OpenOrders account flags
+        return !(!accountInfo.second.accountFlags[0] ||
+                 !accountInfo.second.accountFlags[2]);
+      });
   return spotOpenOrdersAccounts;
 }
 

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -179,11 +179,11 @@ std::map<std::string, serum_v3::OpenOrders> MangoAccount::loadOpenOrders(
       [](auto &accountInfo) {
         // Check initialized and OpenOrders account flags
         return !((accountInfo.second.accountFlags &
-                  serum_v3::AccountFlag::Initialized) !=
-                     serum_v3::AccountFlag::Initialized ||
+                  serum_v3::AccountFlags::Initialized) !=
+                     serum_v3::AccountFlags::Initialized ||
                  (accountInfo.second.accountFlags &
-                  serum_v3::AccountFlag::OpenOrders) !=
-                     serum_v3::AccountFlag::OpenOrders);
+                  serum_v3::AccountFlags::OpenOrders) !=
+                     serum_v3::AccountFlags::OpenOrders);
       });
   return spotOpenOrdersAccounts;
 }

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <bitset>
+
 #include "solana.hpp"
 
 namespace serum_v3 {
-enum class AccountFlag: uint64_t {
+enum class AccountFlag : uint64_t {
   Initialized = 1 << 0,
   Market = 1 << 1,
   OpenOrders = 1 << 2,
@@ -14,7 +15,7 @@ enum class AccountFlag: uint64_t {
   Asks = 1 << 6,
   Disabled = 1 << 7
 };
-inline AccountFlag operator& (AccountFlag a, AccountFlag b) {
+inline AccountFlag operator&(AccountFlag a, AccountFlag b) {
   return (AccountFlag)((uint64_t)a & (uint64_t)b);
 }
 #pragma pack(push, 1)
@@ -43,4 +44,4 @@ struct OpenOrders {
   uint8_t padding1[7];
 };
 #pragma pack(pop)
-}
+}  // namespace serum_v3

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -11,7 +11,10 @@ enum class AccountFlags : uint64_t {
   EventQueue = 1 << 4,
   Bids = 1 << 5,
   Asks = 1 << 6,
-  Disabled = 1 << 7
+  Disabled = 1 << 7,
+  Closed = 1 << 8,
+  Permissioned = 1 << 9,
+  CrankAuthorityRequired = 1 << 10
 };
 constexpr AccountFlags operator&(AccountFlags a, AccountFlags b) {
   return (AccountFlags)((uint64_t)a & (uint64_t)b);

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <bitset>
-
 #include "solana.hpp"
 
 namespace serum_v3 {

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -13,7 +13,7 @@ enum class AccountFlags : uint64_t {
   Asks = 1 << 6,
   Disabled = 1 << 7
 };
-inline AccountFlags operator&(AccountFlags a, AccountFlags b) {
+constexpr AccountFlags operator&(AccountFlags a, AccountFlags b) {
   return (AccountFlags)((uint64_t)a & (uint64_t)b);
 }
 #pragma pack(push, 1)

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -21,14 +21,6 @@ inline AccountFlag operator&(AccountFlag a, AccountFlag b) {
 #pragma pack(push, 1)
 struct OpenOrders {
   uint8_t padding0[5];
-  // Account Flags:
-  //  accountFlags[0] = "initialized"
-  //  accountFlags[1] = "market"
-  //  accountFlags[2] = "openOrders"
-  //  accountFlags[3] = "requestQueue"
-  //  accountFlags[4] = "eventQueue"
-  //  accountFlags[5] = "bids"
-  //  accountFlags[6] = "asks"
   AccountFlag accountFlags;
   solana::PublicKey market;
   solana::PublicKey owner;

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <bitset>
+#include "solana.hpp"
+
+namespace serum_v3 {
+enum class AccountFlag: uint64_t {
+  Initialized = 1 << 0,
+  Market = 1 << 1,
+  OpenOrders = 1 << 2,
+  RequestQueue = 1 << 3,
+  EventQueue = 1 << 4,
+  Bids = 1 << 5,
+  Asks = 1 << 6,
+  Disabled = 1 << 7
+};
+inline AccountFlag operator& (AccountFlag a, AccountFlag b) {
+  return (AccountFlag)((uint64_t)a & (uint64_t)b);
+}
+#pragma pack(push, 1)
+struct OpenOrders {
+  uint8_t padding0[5];
+  // Account Flags:
+  //  accountFlags[0] = "initialized"
+  //  accountFlags[1] = "market"
+  //  accountFlags[2] = "openOrders"
+  //  accountFlags[3] = "requestQueue"
+  //  accountFlags[4] = "eventQueue"
+  //  accountFlags[5] = "bids"
+  //  accountFlags[6] = "asks"
+  AccountFlag accountFlags;
+  solana::PublicKey market;
+  solana::PublicKey owner;
+  uint64_t baseTokenFree;
+  uint64_t baseTokenTotal;
+  uint64_t quoteTokenFree;
+  uint64_t quoteTokenTotal;
+  __uint128_t freeSlotBits;
+  __uint128_t isBidBits;
+  __uint128_t orders[128];
+  uint64_t clientIds[128];
+  uint64_t referrerRebatesAccrued;
+  uint8_t padding1[7];
+};
+#pragma pack(pop)
+}

--- a/include/serum_v3.hpp
+++ b/include/serum_v3.hpp
@@ -5,7 +5,7 @@
 #include "solana.hpp"
 
 namespace serum_v3 {
-enum class AccountFlag : uint64_t {
+enum class AccountFlags : uint64_t {
   Initialized = 1 << 0,
   Market = 1 << 1,
   OpenOrders = 1 << 2,
@@ -15,13 +15,13 @@ enum class AccountFlag : uint64_t {
   Asks = 1 << 6,
   Disabled = 1 << 7
 };
-inline AccountFlag operator&(AccountFlag a, AccountFlag b) {
-  return (AccountFlag)((uint64_t)a & (uint64_t)b);
+inline AccountFlags operator&(AccountFlags a, AccountFlags b) {
+  return (AccountFlags)((uint64_t)a & (uint64_t)b);
 }
 #pragma pack(push, 1)
 struct OpenOrders {
   uint8_t padding0[5];
-  AccountFlag accountFlags;
+  AccountFlags accountFlags;
   solana::PublicKey market;
   solana::PublicKey owner;
   uint64_t baseTokenFree;


### PR DESCRIPTION
#13 
Took me a while to deserialize Serum's [`OpenOrders`](https://github.com/project-serum/serum-dex/blob/master/dex/src/state.rs#L587).
- Tested with `positions.ts` and a few accounts.
- Unit tests probably needed but can be added later when more complex calculations are added.