### PR TITLE
Check BlockHeight for tx getSignatureStatuses

### DIFF
--- a/examples/placeOrder.cpp
+++ b/examples/placeOrder.cpp
@@ -20,7 +20,7 @@ int main() {
       connection.getAccountInfo<mango_v3::PerpMarket>(perpMarketPk.toBase58());
   assert(market.mangoGroup.toBase58() == config.group);
 
-  const auto recentBlockhash = connection.getRecentBlockhash_DEPRECATED();
+  const auto recentBlockhash = connection.getLatestBlockhash();
   const auto groupPk = solana::PublicKey::fromBase58(config.group);
   const auto programPk = solana::PublicKey::fromBase58(config.program);
   const auto keypair =

--- a/examples/sendTransaction.cpp
+++ b/examples/sendTransaction.cpp
@@ -42,13 +42,8 @@ int main() {
       recentBlockHash.lastValidBlockHeight +
       mango_v3::MAXIMUM_NUMBER_OF_BLOCKS_FOR_TRANSACTION;
   while (true) {
-    // Asynchronously fetch blockHeight
-    std::future<uint64_t> blockHeightFut =
-        std::async(std::launch::async, [&connection]() -> uint64_t {
-          return connection.getBlockHeight("confirmed");
-        });
     // Check if we are past validBlockHeight
-    auto currentBlockHeight = blockHeightFut.get();
+    auto currentBlockHeight = connection.getBlockHeight("confirmed");
     if (timeoutBlockHeight <= currentBlockHeight) {
       spdlog::error("Timed out for txid: {}, current BlockHeight: {}", b58Sig,
                     currentBlockHeight);

--- a/examples/sendTransaction.cpp
+++ b/examples/sendTransaction.cpp
@@ -2,8 +2,10 @@
 #include <spdlog/spdlog.h>
 
 #include <chrono>
+#include <future>
 #include <nlohmann/json.hpp>
 
+#include "mango_v3.hpp"
 #include "solana.hpp"
 
 using json = nlohmann::json;
@@ -12,74 +14,68 @@ int main() {
   std::string rpc_url = "https://mango.devnet.rpcpool.com";
   auto connection = solana::rpc::Connection(rpc_url);
   // 1. fetch recent blockhash to anchor tx to
-  const json req = connection.getBlockhashRequest();
-  const std::string jsonSerialized = req.dump();
-  spdlog::info("REQ: {}", jsonSerialized);
+  auto recentBlockHash = connection.getLatestBlockhash();
 
-  cpr::Response r =
-      cpr::Post(cpr::Url{rpc_url}, cpr::Body{jsonSerialized},
-                cpr::Header{{"Content-Type", "application/json"}});
+  // 2. assemble tx
+  const solana::PublicKey feePayer = solana::PublicKey::fromBase58(
+      "8K4Exjnvs3ZJQDE78zmFoax5Sh4cEVdbk1D1r17Wxuud");
+  const solana::PublicKey memoProgram =
+      solana::PublicKey::fromBase58(solana::MEMO_PROGRAM_ID);
+  const std::string memo = "Hello \xF0\x9F\xA5\xAD";
 
-  if (r.status_code == 0 || r.status_code >= 400) {
-    spdlog::error("Error: {}, {}", r.status_code, r.error.message);
-    return 1;
-  } else {
-    spdlog::info("RES: {}", r.text);
+  const solana::CompiledInstruction ix = {
+      1, {}, std::vector<uint8_t>(memo.begin(), memo.end())};
 
-    json res = json::parse(r.text);
+  const solana::CompiledTransaction tx = {
+      recentBlockHash, {feePayer, memoProgram}, {ix}, 1, 0, 1};
 
-    const std::string encoded = res["result"]["value"]["blockhash"];
-    const solana::PublicKey recentBlockHash =
-        solana::PublicKey::fromBase58(encoded);
+  // 3. send & sign tx
+  const auto keypair =
+      solana::Keypair::fromFile("../tests/fixtures/solana/id.json");
+  const auto b58Sig = connection.signAndSendTransaction(keypair, tx);
+  spdlog::info(
+      "sent tx. check: https://explorer.solana.com/tx/{}?cluster=devnet",
+      b58Sig);
 
-    // 2. assemble tx
-    const solana::PublicKey feePayer = solana::PublicKey::fromBase58(
-        "8K4Exjnvs3ZJQDE78zmFoax5Sh4cEVdbk1D1r17Wxuud");
-    const solana::PublicKey memoProgram =
-        solana::PublicKey::fromBase58(solana::MEMO_PROGRAM_ID);
-    const std::string memo = "Hello \xF0\x9F\xA5\xAD";
+  // 4. wait for tx to confirm
+  const auto start = std::chrono::system_clock::now();
+  const auto timeoutBlockHeight = recentBlockHash.lastValidBlockHeight + mango_v3::MAXIMUM_NUMBER_OF_BLOCKS_FOR_TRANSACTION;
+  while (true) {
+    const auto sinceStart = std::chrono::system_clock::now() - start;
+    // Asynchronously fetch blockHeight
+    std::future<uint64_t> blockHeightFut = std::async(std::launch::async, [&connection]()-> uint64_t {
+      return connection.getBlockHeight();
+    });
+    const auto secondsSinceStart =
+        std::chrono::duration_cast<std::chrono::seconds>(sinceStart).count();
+    if (secondsSinceStart > 90)
+      throw std::runtime_error(
+          "timeout reached - could not confirm transaction " + b58Sig);
 
-    const solana::CompiledInstruction ix = {
-        1, {}, std::vector<uint8_t>(memo.begin(), memo.end())};
+    const json req = connection.getSignatureStatuses({b58Sig});
+    const std::string jsonSerialized = req.dump();
+    spdlog::info("REQ: {}", jsonSerialized);
 
-    const solana::CompiledTransaction tx = {
-        recentBlockHash, {feePayer, memoProgram}, {ix}, 1, 0, 1};
+    cpr::Response r =
+        cpr::Post(cpr::Url{rpc_url}, cpr::Body{jsonSerialized},
+                  cpr::Header{{"Content-Type", "application/json"}});
+    if (r.status_code == 0 || r.status_code >= 400) {
+      spdlog::error("Error: {}, {}", r.status_code, r.error.message);
+      return EXIT_FAILURE;
+    } else {
+      spdlog::info("RES: {}", r.text);
+      json res = json::parse(r.text);
 
-    // 3. send & sign tx
-    const auto keypair =
-        solana::Keypair::fromFile("../tests/fixtures/solana/id.json");
-    const auto b58Sig = connection.signAndSendTransaction(keypair, tx);
-    spdlog::info(
-        "sent tx. check: https://explorer.solana.com/tx/{}?cluster=devnet",
-        b58Sig);
-
-    // 4. wait for tx to confirm
-    const auto start = std::chrono::system_clock::now();
-    while (true) {
-      const auto sinceStart = std::chrono::system_clock::now() - start;
-      const auto secondsSinceStart =
-          std::chrono::duration_cast<std::chrono::seconds>(sinceStart).count();
-      if (secondsSinceStart > 90)
-        throw std::runtime_error(
-            "timeout reached - could not confirm transaction " + b58Sig);
-
-      const json req = connection.getSignatureStatuses({b58Sig});
-      const std::string jsonSerialized = req.dump();
-      spdlog::info("REQ: {}", jsonSerialized);
-
-      cpr::Response r =
-          cpr::Post(cpr::Url{rpc_url}, cpr::Body{jsonSerialized},
-                    cpr::Header{{"Content-Type", "application/json"}});
-      if (r.status_code == 0 || r.status_code >= 400) {
-        spdlog::error("Error: {}, {}", r.status_code, r.error.message);
-        return 1;
-      } else {
-        spdlog::info("RES: {}", r.text);
-        json res = json::parse(r.text);
-
-        if (res["result"]["value"][0] != nullptr) break;
-      }
+      if (res["result"]["value"][0] != nullptr)
+        return EXIT_SUCCESS;
     }
+    // Check if we are past validBlockHeight
+    auto currentBlockHeight = blockHeightFut.get();
+    if (timeoutBlockHeight <= currentBlockHeight){
+      spdlog::error("Timed out for txid: {}, current BlockHeight: {}", b58Sig, currentBlockHeight);
+      return EXIT_FAILURE;
+    }
+
   }
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/examples/sendTransaction.cpp
+++ b/examples/sendTransaction.cpp
@@ -43,9 +43,10 @@ int main() {
       mango_v3::MAXIMUM_NUMBER_OF_BLOCKS_FOR_TRANSACTION;
   while (true) {
     // Asynchronously fetch blockHeight
-    std::future<uint64_t> blockHeightFut = std::async(
-        std::launch::async,
-        [&connection]() -> uint64_t { return connection.getBlockHeight("confirmed"); });
+    std::future<uint64_t> blockHeightFut =
+        std::async(std::launch::async, [&connection]() -> uint64_t {
+          return connection.getBlockHeight("confirmed");
+        });
     // Check if we are past validBlockHeight
     auto currentBlockHeight = blockHeightFut.get();
     if (timeoutBlockHeight <= currentBlockHeight) {

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -18,6 +18,7 @@ const int INFO_LEN = 32;
 const int QUOTE_INDEX = 15;
 const int EVENT_SIZE = 200;
 const int EVENT_QUEUE_SIZE = 256;
+const int MAXIMUM_NUMBER_OF_BLOCKS_FOR_TRANSACTION = 152;
 
 struct Config {
   std::string endpoint;

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -235,7 +235,7 @@ struct CompiledTransaction {
 
 namespace rpc {
 using json = nlohmann::json;
-static inline json jsonRequest(const std::string &method,
+inline json jsonRequest(const std::string &method,
                         const json &params = nullptr) {
   json req = {{"jsonrpc", "2.0"}, {"id", 1}, {"method", method}};
   if (params != nullptr) req["params"] = params;

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -98,6 +98,18 @@ Blockhash Connection::getLatestBlockhash(const std::string &commitment) {
   return {PublicKey::fromBase58(encoded), lastValidBlockHeight};
 }
 
+uint64_t Connection::getBlockHeight(const std::string &commitment){
+  const json req = getBlockhashRequest(commitment, "getBlockHeight");
+  cpr::Response r =
+      cpr::Post(cpr::Url{rpc_url_}, cpr::Body{req.dump()},
+                cpr::Header{{"Content-Type", "application/json"}});
+  if (r.status_code != 200)
+    throw std::runtime_error("unexpected status_code " +
+                             std::to_string(r.status_code));
+  json res = json::parse(r.text);
+  const uint64_t blockHeight = res["result"];
+  return blockHeight;
+}
 json Connection::getSignatureStatuses(
     const std::vector<std::string> &signatures, bool searchTransactionHistory) {
   const json params = {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -68,7 +68,7 @@ TEST_CASE("decode mango_v3 Fill") {
 }
 
 TEST_CASE("compile memo transaction") {
-  const solana::PublicKey recentBlockhash = {};
+  const solana::Blockhash recentBlockhash = {};
   const auto feePayer = solana::PublicKey::fromBase58(
       "8K4Exjnvs3ZJQDE78zmFoax5Sh4cEVdbk1D1r17Wxuud");
   const auto memoProgram =
@@ -79,7 +79,7 @@ TEST_CASE("compile memo transaction") {
   const auto ctx = solana::CompiledTransaction::fromInstructions(
       {ix}, feePayer, recentBlockhash);
 
-  CHECK_EQ(recentBlockhash, ctx.recentBlockhash);
+  CHECK_EQ(recentBlockhash.publicKey, ctx.recentBlockhash.publicKey);
   CHECK_EQ(2, ctx.accounts.size());
   CHECK_EQ(feePayer, ctx.accounts[0]);
   CHECK_EQ(memoProgram, ctx.accounts[1]);


### PR DESCRIPTION
- CompiledTransaction now uses new BlockHash with `validBlockHeight`.
- Added `getBlockHeight` rpc method.
- Modified `sendTransaction` to check validBlockHeight when checking signature statuses.