### PR TITLE
adds getBlockTime, getClusterNodes, getFeeForMessage, getLargestAccounts,  getRecentPerformanceSamples method

### DIFF
--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -301,11 +301,11 @@ struct GetSlotConfig {
  */
 void to_json(json &j, const GetSlotConfig &config);
 
-struct largestAccountsConfig {
+struct LargestAccountsConfig {
   std::optional<Commitment> commitment = std::nullopt;
   std::optional<std::string> filter = std::nullopt;
 };
-void to_json(json &j, const largestAccountsConfig &config);
+void to_json(json &j, const LargestAccountsConfig &config);
 
 struct SignatureStatus {
   /** when the transaction was processed */
@@ -824,7 +824,7 @@ class Connection {
    *Returns the 20 largest accounts, by lamport balance
    */
   RpcResponseAndContext<std::vector<LargestAccounts>> getLargestAccounts(
-      const largestAccountsConfig &config = largestAccountsConfig{}) const;
+      const LargestAccountsConfig &config = LargestAccountsConfig{}) const;
 
   /**
    * Fetch the current status of a signature

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -324,6 +324,40 @@ struct EpochInfo {
 };
 
 void from_json(const json &j, EpochInfo &epochinfo);
+
+struct Nodes {
+  std::optional<uint64_t> featureSet = std::nullopt;
+  std::optional<std::string> gossip = std::nullopt;
+  std::optional<std::string> pubkey = std::nullopt;
+  std::optional<std::string> rpc = std::nullopt;
+  std::optional<uint64_t> shredVersion = std::nullopt;
+  std::optional<std::string> tpu = std::nullopt;
+  std::optional<std::string> version = std::nullopt;
+};
+
+void from_json(const json &j, Nodes &nodes);
+
+struct LargestAccounts {
+  uint64_t lamports;
+  std::string address;
+};
+
+void from_json(const json &j, LargestAccounts &largestaccounts);
+
+struct RecentPerformanceSamples {
+  uint64_t numSlots;
+  uint64_t numTransactions;
+  uint64_t samplePeriodSecs;
+  uint64_t slot;
+};
+void from_json(const json &j,
+               RecentPerformanceSamples &recentperformancesamples);
+
+struct getFeeForMessageRes {
+  std::optional<uint64_t> value = std::nullopt;
+};
+void from_json(const json &j, getFeeForMessageRes &res);
+
 /**
  * SignatureStatus to json
  */
@@ -756,6 +790,36 @@ class Connection {
   uint64_t getMinimumBalanceForRentExemption(
       const std::size_t dataLength,
       const commitmentconfig &config = commitmentconfig{}) const;
+
+  /**
+   * Returns the estimated production time of a block.
+   */
+  uint64_t getBlockTime(const uint64_t slot) const;
+
+  /**
+   *Returns information about all the nodes participating in the cluster
+   */
+  std::vector<Nodes> getClusterNodes() const;
+
+  /**
+   *Get the fee the network will charge for a particular Message
+   */
+  getFeeForMessageRes getFeeForMessage(
+      const std::string message,
+      const GetSlotConfig &config = GetSlotConfig{}) const;
+
+  /**
+   *Returns a list of recent performance samples, in reverse slot order.
+   */
+  std::vector<RecentPerformanceSamples> getRecentPerformanceSamples(
+      std::size_t limit) const;
+
+  /**
+   *Returns the 20 largest accounts, by lamport balance
+   */
+  RpcResponseAndContext<std::vector<LargestAccounts>> getLargestAccounts()
+      const;
+
   /**
    * Fetch the current status of a signature
    */

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -301,6 +301,12 @@ struct GetSlotConfig {
  */
 void to_json(json &j, const GetSlotConfig &config);
 
+struct largestAccountsConfig {
+  std::optional<Commitment> commitment = std::nullopt;
+  std::optional<std::string> filter = std::nullopt;
+};
+void to_json(json &j, const largestAccountsConfig &config);
+
 struct SignatureStatus {
   /** when the transaction was processed */
   uint64_t slot;
@@ -817,8 +823,8 @@ class Connection {
   /**
    *Returns the 20 largest accounts, by lamport balance
    */
-  RpcResponseAndContext<std::vector<LargestAccounts>> getLargestAccounts()
-      const;
+  RpcResponseAndContext<std::vector<LargestAccounts>> getLargestAccounts(
+      const largestAccountsConfig &config = largestAccountsConfig{}) const;
 
   /**
    * Fetch the current status of a signature

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -176,7 +176,7 @@ void to_json(json &j, const commitmentconfig &config) {
   }
 }
 
-void to_json(json &j, const largestAccountsConfig &config) {
+void to_json(json &j, const LargestAccountsConfig &config) {
   if (config.commitment.has_value()) {
     j["commitment"] = config.commitment.value();
   }
@@ -751,7 +751,7 @@ getFeeForMessageRes Connection::getFeeForMessage(
 }
 
 RpcResponseAndContext<std::vector<LargestAccounts>>
-Connection::getLargestAccounts(const largestAccountsConfig &config) const {
+Connection::getLargestAccounts(const LargestAccountsConfig &config) const {
   const json params = {config};
   const auto reqJson = jsonRequest("getLargestAccounts", params);
   const json res = sendJsonRpcRequest(reqJson);

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -175,6 +175,15 @@ void to_json(json &j, const commitmentconfig &config) {
     j["commitment"] = config.commitment.value();
   }
 }
+
+void to_json(json &j, const largestAccountsConfig &config) {
+  if (config.commitment.has_value()) {
+    j["commitment"] = config.commitment.value();
+  }
+  if (config.filter.has_value()) {
+    j["filter"] = config.filter.value();
+  }
+}
 ///
 /// SignatureStatus
 void to_json(json &j, const SignatureStatus &status) {
@@ -742,16 +751,14 @@ getFeeForMessageRes Connection::getFeeForMessage(
 }
 
 RpcResponseAndContext<std::vector<LargestAccounts>>
-Connection::getLargestAccounts() const {
-  const json params = {};
+Connection::getLargestAccounts(const largestAccountsConfig &config) const {
+  const json params = {config};
   const auto reqJson = jsonRequest("getLargestAccounts", params);
   const json res = sendJsonRpcRequest(reqJson);
   const std::vector<json> value = res["value"];
   std::vector<LargestAccounts> accounts_list;
   accounts_list.reserve(value.size());
-  for (const json &account : value) {
-    accounts_list.push_back(account);
-  }
+  std::copy(value.begin(), value.end(), std::back_inserter(accounts_list));
   return {res["context"], accounts_list};
 }
 
@@ -763,9 +770,7 @@ std::vector<RecentPerformanceSamples> Connection::getRecentPerformanceSamples(
   const std::vector<json> value = res;
   std::vector<RecentPerformanceSamples> samples_list;
   samples_list.reserve(value.size());
-  for (const json &sample : value) {
-    samples_list.push_back(sample);
-  }
+  std::copy(value.begin(), value.end(), std::back_inserter(samples_list));
   return samples_list;
 }
 

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -212,6 +212,50 @@ void from_json(const json &j, InflationGovernor &inflationgovernor) {
   inflationgovernor.taper = j["taper"];
   inflationgovernor.terminal = j["terminal"];
 }
+
+void from_json(const json &j, Nodes &nodes) {
+  if (!j["featureSet"].is_null()) {
+    nodes.featureSet = std::optional{j["featureSet"]};
+  }
+  if (!j["gossip"].is_null()) {
+    nodes.gossip = std::optional{j["gossip"]};
+  }
+  if (!j["pubkey"].is_null()) {
+    nodes.pubkey = std::optional{j["pubkey"]};
+  }
+  if (!j["rpc"].is_null()) {
+    nodes.rpc = std::optional{j["rpc"]};
+  }
+  if (!j["shredVersion"].is_null()) {
+    nodes.shredVersion = std::optional{j["shredVersion"]};
+  }
+  if (!j["tpu"].is_null()) {
+    nodes.tpu = std::optional{j["tpu"]};
+  }
+  if (!j["version"].is_null()) {
+    nodes.version = std::optional{j["version"]};
+  }
+}
+
+void from_json(const json &j, getFeeForMessageRes &res) {
+  if (!j.is_null()) {
+    res.value = j;
+  }
+}
+
+void from_json(const json &j, LargestAccounts &largestaccounts) {
+  largestaccounts.address = j["address"];
+  largestaccounts.lamports = j["lamports"];
+}
+
+void from_json(const json &j,
+               RecentPerformanceSamples &recentperformancesamples) {
+  recentperformancesamples.numSlots = j["numSlots"];
+  recentperformancesamples.numTransactions = j["numTransactions"];
+  recentperformancesamples.samplePeriodSecs = j["samplePeriodSecs"];
+  recentperformancesamples.slot = j["slot"];
+}
+
 ///
 /// CompactU16
 namespace CompactU16 {
@@ -676,6 +720,53 @@ uint64_t Connection::getMinimumBalanceForRentExemption(
   const json params = {dataLength, config};
   const json reqJson = jsonRequest("getMinimumBalanceForRentExemption", params);
   return sendJsonRpcRequest(reqJson);
+}
+
+uint64_t Connection::getBlockTime(const uint64_t slot) const {
+  const json params = {slot};
+  const json reqJson = jsonRequest("getBlockTime", params);
+  return sendJsonRpcRequest(reqJson);
+}
+
+std::vector<Nodes> Connection::getClusterNodes() const {
+  const json params = {};
+  const json reqJson = jsonRequest("getClusterNodes", params);
+  return sendJsonRpcRequest(reqJson);
+}
+
+getFeeForMessageRes Connection::getFeeForMessage(
+    const std::string message, const GetSlotConfig &config) const {
+  const json params = {message, config};
+  const json reqJson = jsonRequest("getFeeForMessage", params);
+  return sendJsonRpcRequest(reqJson)["value"];
+}
+
+RpcResponseAndContext<std::vector<LargestAccounts>>
+Connection::getLargestAccounts() const {
+  const json params = {};
+  const auto reqJson = jsonRequest("getLargestAccounts", params);
+  const json res = sendJsonRpcRequest(reqJson);
+  const std::vector<json> value = res["value"];
+  std::vector<LargestAccounts> accounts_list;
+  accounts_list.reserve(value.size());
+  for (const json &account : value) {
+    accounts_list.push_back(account);
+  }
+  return {res["context"], accounts_list};
+}
+
+std::vector<RecentPerformanceSamples> Connection::getRecentPerformanceSamples(
+    std::size_t limit) const {
+  const json params = {limit};
+  const auto reqJson = jsonRequest("getRecentPerformanceSamples", params);
+  const json res = sendJsonRpcRequest(reqJson);
+  const std::vector<json> value = res;
+  std::vector<RecentPerformanceSamples> samples_list;
+  samples_list.reserve(value.size());
+  for (const json &sample : value) {
+    samples_list.push_back(sample);
+  }
+  return samples_list;
 }
 
 }  // namespace rpc

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -859,3 +859,46 @@ TEST_CASE("getMinimumBalanceForRentExemption") {
       512, solana::commitmentconfig{solana::Commitment::FINALIZED});
   CHECK_GE(minimumBalance, 0);
 }
+
+TEST_CASE("getMinimumBalanceForRentExemption") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto minimumBalance = connection.getMinimumBalanceForRentExemption(
+      512, solana::commitmentconfig{solana::Commitment::FINALIZED});
+  CHECK_GE(minimumBalance, 0);
+}
+
+TEST_CASE("getBlockTime") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto slot = connection.getFirstAvailableBlock();
+  const auto BlockTime = connection.getBlockTime(slot);
+  CHECK_GT(BlockTime, 0);
+}
+
+TEST_CASE("getClusterNodes") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto clusterNodes = connection.getClusterNodes();
+  CHECK_GT(clusterNodes.size(), 0);
+}
+
+TEST_CASE("getFeeForMessage") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto FeeForMessage = connection.getFeeForMessage(
+      "AQABAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAA");
+  if (FeeForMessage.value.has_value()) {
+    CHECK_GT(FeeForMessage.value.value(), 0);
+  }
+}
+
+TEST_CASE("getLargestAccount") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto LargestAccount = connection.getLargestAccounts();
+  CHECK_EQ(LargestAccount.value.size(), 20);
+}
+
+TEST_CASE("getRecentPerformanceSamples") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto RecentPerformanceSamples =
+      connection.getRecentPerformanceSamples(4);
+  CHECK_EQ(RecentPerformanceSamples[0].samplePeriodSecs, 60);
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -860,13 +860,6 @@ TEST_CASE("getMinimumBalanceForRentExemption") {
   CHECK_GE(minimumBalance, 0);
 }
 
-TEST_CASE("getMinimumBalanceForRentExemption") {
-  const auto connection = solana::rpc::Connection(solana::DEVNET);
-  const auto minimumBalance = connection.getMinimumBalanceForRentExemption(
-      512, solana::commitmentconfig{solana::Commitment::FINALIZED});
-  CHECK_GE(minimumBalance, 0);
-}
-
 TEST_CASE("getBlockTime") {
   const auto connection = solana::rpc::Connection(solana::DEVNET);
   const auto slot = connection.getFirstAvailableBlock();


### PR DESCRIPTION
The pr adds 5 json rpc requests of issue #39 
* [getBlockTime](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getBlockTime)
* [getClusterNodes](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getClusterNodes)
* [getFeeForMessage](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getFeeForMessage)
* [getLargestAccounts](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getLargestAccounts)
* [getRecentPerformanceSamples](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getRecentPerformanceSamples)