### PR TITLE
adds getSlotLeaders, getSupply, getTokenAccountBalance, getVoteAccounts, ,getSignaturesForAddress methods

### DIFF
--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -374,6 +374,84 @@ void to_json(json &j, const SignatureStatus &status);
  */
 void from_json(const json &j, SignatureStatus &status);
 
+struct GetSupplyConfig {
+  /** The level of commitment desired */
+  std::optional<Commitment> commitment = std::nullopt;
+  /** The minimum slot that the request can be evaluated at */
+  std::optional<bool> excludeNonCirculatingAccountsList = std::nullopt;
+};
+
+struct GetVoteAccountsConfig {
+  std::optional<Commitment> commitment = std::nullopt;
+  std::optional<std::string> votePubkey = std::nullopt;
+  std::optional<bool> keepUnstakedDelinquents = std::nullopt;
+  std::optional<uint64_t> delinquentSlotDistance = std::nullopt;
+};
+
+struct GetSignatureAddressConfig {
+  std::optional<uint64_t> limit = std::nullopt;
+  std::optional<std::string> before = std::nullopt;
+  std::optional<std::string> until = std::nullopt;
+  std::optional<Commitment> commitment = std::nullopt;
+  std::optional<uint64_t> minContextSlot = std::nullopt;
+};
+
+struct Supply {
+  uint64_t circulating;
+  uint64_t nonCirculating;
+  std::optional<std::vector<std::string>> nonCirculatingAccounts = std::nullopt;
+  uint64_t total;
+};
+
+void from_json(const json &j, Supply &supply);
+
+struct TokenAccountBalance {
+  std::string amount;
+  uint64_t decimals;
+  double uiAmount;
+  std::string uiAmountString;
+};
+
+void from_json(const json &j, TokenAccountBalance &tokenaccountbalance);
+
+struct Current {
+  uint64_t commission;
+  bool epochVoteAccount;
+  std::vector<std::vector<uint64_t>> epochCredits;
+  std::string nodePubkey;
+  uint64_t lastVote;
+  uint64_t activatedStake;
+  std::string votePubkey;
+};
+
+struct Delinquent {
+  uint64_t commission;
+  bool epochVoteAccount;
+  std::vector<std::vector<uint64_t>> epochCredits;
+  std::string nodePubkey;
+  uint64_t lastVote;
+  uint64_t activatedStake;
+  std::string votePubkey;
+};
+
+struct VoteAccounts {
+  std::vector<Current> current;
+  std::vector<Delinquent> delinquent;
+};
+
+struct SignaturesAddress {
+  std::optional<uint64_t> blockTime = std::nullopt;
+  std::optional<Commitment> confirmationStatus = std::nullopt;
+  std::optional<std::string> err = std::nullopt;
+  std::optional<std::string> memo = std::nullopt;
+  std::string signature;
+  uint64_t slot;
+};
+
+void from_json(const json &j, SignaturesAddress &signaturesaddress);
+void to_json(json &j, const GetSupplyConfig &config);
+void to_json(json &j, const GetVoteAccountsConfig &config);
+
 /**
  * Extra contextual information for RPC responses
  */
@@ -832,6 +910,40 @@ class Connection {
   RpcResponseAndContext<std::optional<SignatureStatus>> getSignatureStatus(
       const std::string &signature,
       bool searchTransactionHistory = false) const;
+
+  /**
+   * Returns the slot leaders for a given slot range
+   */
+  std::vector<std::string> getSlotLeaders(uint64_t startSlot,
+                                          uint64_t limit) const;
+
+  /**
+   * Returns information about the current supply.
+   */
+  RpcResponseAndContext<Supply> getSupply(
+      const GetSupplyConfig &config = GetSupplyConfig{}) const;
+
+  /**
+   * Returns the token balance of an SPL Token account.
+   */
+  RpcResponseAndContext<TokenAccountBalance> getTokenAccountBalance(
+      const std::string pubkey,
+      const commitmentconfig &config = commitmentconfig{}) const;
+
+  /**
+   * Returns the account info and associated stake for all the voting accounts
+   * in the current bank.
+   */
+  VoteAccounts getVoteAccounts(
+      const GetVoteAccountsConfig &config = GetVoteAccountsConfig{}) const;
+
+  /**
+   * Returns signatures for confirmed transactions that include the given
+   * address in their accountKeys list.
+   */
+  std::vector<SignaturesAddress> getSignaturesForAddress(
+      std::string pubkey, const GetSignatureAddressConfig &config =
+                              GetSignatureAddressConfig{}) const;
 
   /**
    * Fetch parsed account info for the specified public key

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -895,3 +895,43 @@ TEST_CASE("getRecentPerformanceSamples") {
       connection.getRecentPerformanceSamples(4);
   CHECK_EQ(RecentPerformanceSamples[0].samplePeriodSecs, 60);
 }
+
+TEST_CASE("getSlotLeaders") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto slot = connection.getSlot();
+  const auto slotLeaders = connection.getSlotLeaders(slot, 10);
+  CHECK_GT(slotLeaders.size(), 0);
+}
+
+TEST_CASE("getSupply") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto supply = connection.getSupply();
+  CHECK_GT(supply.value.circulating, 0);
+  CHECK_GT(supply.value.nonCirculating, 0);
+  CHECK_GT(supply.value.nonCirculatingAccounts.value().size(), 0);
+  CHECK_GT(supply.value.total, 0);
+}
+
+TEST_CASE("getVoteAccounts") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto VoteAccounts = connection.getVoteAccounts();
+  CHECK_GT(VoteAccounts.current.size() + VoteAccounts.delinquent.size(), 0);
+}
+
+TEST_CASE("getTokenAccountBalance") {
+  const auto connection = solana::rpc::Connection(solana::MAINNET_BETA);
+  const auto accountBalance = connection.getTokenAccountBalance(
+      "DhzDoryP2a4rMK2bcWwJxrE2uW6ir81ES8ZwJJPPpxDN");
+  CHECK_GT(accountBalance.value.amount.size(), 0);
+  CHECK_GE(accountBalance.value.decimals, 0);
+  CHECK_GT(accountBalance.value.uiAmount, 0);
+  CHECK_GT(accountBalance.value.uiAmountString.size(), 0);
+}
+
+TEST_CASE("getSignaturesForAddress") {
+  const auto connection = solana::rpc::Connection(solana::DEVNET);
+  const auto SignaturesForAddress = connection.getSignaturesForAddress(
+      "Vote111111111111111111111111111111111111111",
+      solana::GetSignatureAddressConfig{2});
+  CHECK_EQ(SignaturesForAddress.size(), 2);
+}


### PR DESCRIPTION
The pr adds 5 json rpc requests of issue #39 :
* [getSlotLeaders](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getSlotLeaders)
* [getSupply](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getSupply)
* [ getTokenAccountBalance](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getTokenAccountBalance)
* [getVoteAccounts](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getVoteAccounts)
* [getSignaturesForAddress](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getSignaturesForAddress)