### PR TITLE
Slot change subscribe and unsubscribe

### DIFF
--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -1056,6 +1056,13 @@ class WebSocketSubscriber {
   /// @brief remove the account change listener for the given id
   /// @param sub_id the id for which removing subscription is needed
   void removeAccountChangeListener(RequestIdType sub_id);
+
+  int onSlotChange(Callback callback,
+                   const Commitment &commitment = Commitment::FINALIZED,
+                   Callback on_subscibe = nullptr,
+                   Callback on_unsubscribe = nullptr);
+
+  void removeSlotChangeListener(RequestIdType sub_id);
 };
 }  // namespace subscription
 }  // namespace rpc

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -1028,6 +1028,31 @@ int WebSocketSubscriber::onAccountChange(const solana::PublicKey &pub_key,
 void WebSocketSubscriber::removeAccountChangeListener(RequestIdType sub_id) {
   sess->unsubscribe(sub_id);
 }
+
+int WebSocketSubscriber::onSlotChange(Callback callback,
+                                      const Commitment &commitment,
+                                      Callback on_subscibe,
+                                      Callback on_unsubscribe) {
+  // create parameters using the user provided input
+  json param = json::array();
+
+  // create a new request content
+  RequestContent req(curr_id, "slotSubscribe", "slotUnsubscribe", callback,
+                     std::move(param), on_subscibe, on_unsubscribe);
+
+  // subscribe the new request content
+  sess->subscribe(req);
+
+  // increase the curr_id so that it can be used for the next request content
+  curr_id += 2;
+
+  return req.id;
+}
+
+void WebSocketSubscriber::removeSlotChangeListener(RequestIdType sub_id) {
+  sess->unsubscribe(sub_id);
+}
+
 }  // namespace subscription
 }  // namespace rpc
 }  // namespace solana

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -983,3 +983,21 @@ TEST_CASE("getBlocks") {
   CHECK_GE(Blocks[0], startslot);
   CHECK_LE(Blocks[Blocks.size() - 1], latestslot);
 }
+
+TEST_CASE("slot change subscribe and unsubscribe") {
+  solana::rpc::subscription::WebSocketSubscriber sub("api.devnet.solana.com",
+                                                     "80");
+  int num_notif, fin_number;
+  auto on_callback = [&num_notif](const json&) { ++num_notif; };
+  auto on_subscribe = [&num_notif](const json&) { num_notif = 0; };
+  auto on_unsubscribe = [&num_notif, &fin_number](const json&) {
+    fin_number = num_notif;
+  };
+  int sub_id = sub.onSlotChange(on_callback, solana::Commitment::CONFIRMED,
+                                on_subscribe, on_unsubscribe);
+  sleep(10);
+  CHECK_GT(num_notif, 0);
+  sub.removeSlotChangeListener(sub_id);
+  sleep(10);
+  CHECK_EQ(num_notif, fin_number);
+}


### PR DESCRIPTION
This pull request implements the [onSlotChange](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#onSlotChange) and [removeSlotChangeListener](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#removeSlotChangeListener) function related to issue number https://github.com/mschneider/solcpp/issues/41. The goal here is to get notification every time a slot is changed.